### PR TITLE
Position of LDFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PREFIX?=/usr/local
 CONFDIR?=${PREFIX}/etc/bpfcountd
 
 bpfcountd: main.o list.o usock.o filters.o util.o
-	$(CC) ${LDFLAGS} main.o list.o usock.o filters.o util.o -o ${NAME}
+	$(CC) main.o list.o usock.o filters.o util.o -o ${NAME} ${LDFLAGS}
 
 all: test bpfcountd
 


### PR DESCRIPTION
First of all: pretty nice work! Like it!

But according to [1] the order of specified dependencies does matter to the linker.

[1] http://stackoverflow.com/questions/45135/why-does-the-order-in-which-libraries-are-linked-sometimes-cause-errors-in-gcc