### PR TITLE
Fix buffer size for snprintf

### DIFF
--- a/main.c
+++ b/main.c
@@ -158,10 +158,10 @@ int main(int argc, char *argv[]) {
 
 			list_foreach(ctx.filters_ctx.filters, f) {
 				struct filter *tmp = list_data(f, struct filter);
-				char buf[1024];
+				char buf[1067];
 				memset(buf, 0x00, sizeof(buf));
 
-				snprintf(buf, 1024, "%s:%llu:%llu\n", tmp->id, tmp->bytes_count, tmp->packets_count);
+				snprintf(buf, 1067, "%s:%llu:%llu\n", tmp->id, tmp->bytes_count, tmp->packets_count);
 				usock_sendstr(usock_client, buf);
 			}
 


### PR DESCRIPTION
The maximum length was miscalculated resulting in a format truncation warning.
Correct size: 1024 (tmp->id) + 1 (":") + 20 ("%llu") + 1 (":") + 20 ("%llu") + 1 ("\n") = 1067