### PR TITLE
Makefile: allow overriding CC, CFLAGS and LDFLAGS from env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-CC=gcc
+CC?=gcc
 
-CFLAGS=-Wall -Werror -ggdb
-LDFLAGS=-lpcap
+CFLAGS+=-Wall -Werror -ggdb
+LDFLAGS?=-lpcap
 NAME=bpfcountd
 PREFIX?=/usr/local
 
 CONFDIR?=${PREFIX}/etc/bpfcountd
 
 bpfcountd: main.o list.o usock.o filters.o util.o
-	$(CC) main.o list.o usock.o filters.o util.o -o ${NAME} ${LDFLAGS}
+	$(CC) ${CFLAGS} main.o list.o usock.o filters.o util.o -o ${NAME} ${LDFLAGS}
 
 all: test bpfcountd
 


### PR DESCRIPTION
Useful if compiling against a library from a custom directory,
for instance a modified lipcap.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>