### PR TITLE
filter: introducing rule substitutions via ${RULENAME}

### DIFF
--- a/filters.h
+++ b/filters.h
@@ -7,6 +7,7 @@
 
 struct filter {
 	char id[1024];
+	char *bpf_str;
 	struct bpf_program *bpf;
 	unsigned long long packets_count;
 	unsigned long long bytes_count;
@@ -19,7 +20,7 @@ typedef struct {
 
 void filters_init(filters_ctx *ctx, pcap_t* pcap_ctx);
 void filters_finish(filters_ctx *ctx);
-void filters_add(filters_ctx *ctx, const char *id, const char* bpf_str);
+void filters_add(filters_ctx *ctx, const char *id, char *bpf_str);
 void filters_load(filters_ctx *ctx, const char *filterfile_path, const char* mac_addr);
 
 void filters_process(filters_ctx *ctx, const struct pcap_pkthdr *pkthdr, const u_char *packet);

--- a/util.c
+++ b/util.c
@@ -23,6 +23,7 @@ void get_mac(char *dest, const char *iface) {
 }
 
 void strnrepl(const char *token, const char *replace, char *str, size_t n) {
+	const size_t str_br_len = strlen("()");
 	char *ptr = str;
 	char *p_behind;
 	size_t length_new = strlen(str);
@@ -36,15 +37,24 @@ void strnrepl(const char *token, const char *replace, char *str, size_t n) {
 			return;
 
 		// calculate the new length and check for overflow
-		length_new += strlen(replace) - strlen(token);
+		length_new += strlen(replace) - strlen(token) + str_br_len;
 		if (length_new >= n)
 			return;
 
 		// this points to the position behind the token
 		p_behind = ptr + strlen(token);
 
-		memmove(ptr + strlen(replace), p_behind, strlen(p_behind));
+		// making room for replacement
+		memmove(ptr + strlen(replace) + str_br_len, p_behind,
+			strlen(p_behind));
+
+		// inserting replacement
+		*ptr = '(';
+		ptr += 1;
 		memcpy(ptr, replace, strlen(replace));
+		ptr += strlen(replace);
+		*ptr = ')';
+
 		str[length_new] = 0x00;
 	}
 }


### PR DESCRIPTION
This allows to reuse a previously defined filter. For instance like:

MDNS;udp port 5353
MDNS4;ip && ${MDNS}
MDNS6;ip6 && ${MDNS}

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>