### PR TITLE
Fix hangs on quiet interface with epoll for pcap handler + unix socket

### DIFF
--- a/usock.h
+++ b/usock.h
@@ -4,7 +4,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-int usock_prepare(const char* path);
+int usock_prepare(const char* path, const int epoll_fd);
 int usock_accept(int sock);
 void usock_finish(int sock);
 void usock_sendstr(int client_sock, const char* str);


### PR DESCRIPTION
Previously if no packets were received on an interface bpfcountd would
hang: It would neither respond to a Ctrl+c (SIGINT) nor to a unix socket
client because it would keep blocking on pcap_dispatch().

Avoid this by introducing epoll for the pcap handler and unix socket.
epoll_wait() will return when there is a new (batch of) packets from the
pcap handler, if there is a connection request from the unix socket or
if there is an interrupt from a signal handler.

This should also make the unix socket a lot more responsive.

epoll infrastructure will also help us to move the pcap filtering from
userspace to kernelspace later, to improve performance. That is epoll
allows us to easily have and handle multiple, per filter rule pcap
handlers later.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>