### PR TITLE
WIP / DONT MERGE: Switch from userspace to kernelspace BPF filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-CC=gcc
+CC?=gcc
 
-CFLAGS=-Wall -Werror -ggdb
-LDFLAGS=-lpcap
+CFLAGS+=-Wall -Werror -ggdb
+LDFLAGS?=-lpcap
 NAME=bpfcountd
 PREFIX?=/usr/local
 
 CONFDIR?=${PREFIX}/etc/bpfcountd
 
 bpfcountd: main.o list.o usock.o filters.o util.o
-	$(CC) main.o list.o usock.o filters.o util.o -o ${NAME} ${LDFLAGS}
+	$(CC) ${CFLAGS} main.o list.o usock.o filters.o util.o -o ${NAME} ${LDFLAGS}
 
 all: test bpfcountd
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC?=gcc
 
 CFLAGS+=-Wall -Werror -ggdb
-LDFLAGS?=-lpcap
+LDFLAGS?=-lpcap -lpthread
 NAME=bpfcountd
 PREFIX?=/usr/local
 

--- a/filters.c
+++ b/filters.c
@@ -2,13 +2,14 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <sys/epoll.h> // for epoll_ctl(), struct epoll_event
+#include <unistd.h>
 
 #include "util.h"
 
 
-void filters_init(filters_ctx *ctx, pcap_t* pcap_ctx) {
+void filters_init(filters_ctx *ctx) {
 	ctx->filters = list_new();
-	ctx->pcap_ctx = pcap_ctx;
 }
 
 void filters_finish(filters_ctx *ctx) {
@@ -17,8 +18,8 @@ void filters_finish(filters_ctx *ctx) {
 	list_foreach(ctx->filters, f) {
 		struct filter *tmp = list_data(f, struct filter);
 
-		pcap_freecode(tmp->bpf);
-		free(tmp->bpf);
+		close(tmp->fd);
+		pcap_close(tmp->pcap_ctx);
 		free(tmp);
 	}
 
@@ -43,33 +44,101 @@ static void filters_bpfstr_unwind_finish(filters_ctx *ctx)
 		free(list_data(f, struct filter)->bpf_str);
 }
 
-void filters_add(filters_ctx *ctx, const char *id, char *bpf_str) {
+static void filters_prepare_pcap(struct filter *filter, const char* device, int epoll_fd) {
+	struct bpf_program bpf;
+	struct epoll_event event;
+	char errbuf[PCAP_ERRBUF_SIZE];
+
+	memset(&errbuf, 0, sizeof(errbuf));
+
+	filter->pcap_ctx = pcap_create(device, errbuf);
+	// TODO: there could be a warning in errbuf even if handle != NULL
+	if (!filter->pcap_ctx) {
+		fprintf(stderr, "Couldn't open device %s\n", errbuf);
+		exit(1);
+	}
+
+	if (pcap_set_snaplen(filter->pcap_ctx, 0)) {
+		fprintf(stderr, "Error at setting zero snaplen\n");
+		exit(1);
+	}
+
+	if (pcap_set_buffer_size(filter->pcap_ctx, BUFSIZ)) {
+		fprintf(stderr, "Error at setting pcap buffer size\n");
+		exit(1);
+	}
+
+	if (pcap_set_timeout(filter->pcap_ctx, 1000)) {
+		fprintf(stderr, "Error at setting pcap timeout\n");
+		exit(1);
+	}
+
+	if (pcap_setnonblock(filter->pcap_ctx, 1, errbuf) == PCAP_ERROR) {
+		fprintf(stderr, "Can't set pcap handler nonblocking.\n");
+		exit(1);
+	}
+
+	if (pcap_activate(filter->pcap_ctx)) {
+		fprintf(stderr, "Can't activate pcap handler.\n");
+		exit(1);
+	}
+
+	if (pcap_compile(filter->pcap_ctx, &bpf, filter->bpf_str, 0, PCAP_NETMASK_UNKNOWN) == -1) {
+		fprintf(stderr, "Error at compiling bpf \"%s\": %s\n", filter->bpf_str, pcap_geterr(filter->pcap_ctx));
+		exit(1);
+	}
+
+	if (pcap_setfilter(filter->pcap_ctx, &bpf)) {
+		pcap_freecode(&bpf);
+		fprintf(stderr, "Can't set pcap filter\n");
+		exit(1);
+	}
+
+	pcap_freecode(&bpf);
+
+	filter->fd = pcap_get_selectable_fd(filter->pcap_ctx);
+	if (filter->fd == PCAP_ERROR) {
+		fprintf(stderr, "Can't get file descriptor from pcap handler.");
+		exit(1);
+	}
+
+	memset(&event, 0, sizeof(event));
+	event.events = EPOLLIN;
+	event.data.ptr = filter;
+
+	if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, filter->fd, &event)) {
+		fprintf(stderr, "Can't add pcap to epoll.\n");
+		exit(1);
+	}
+}
+
+
+
+void filters_add(filters_ctx *ctx, const char *id, char *bpf_str, const char* device, int epoll_fd) {
 	struct filter *instance = malloc(sizeof(*instance));
 
 	// TODO: document maximum len of id
 	strncpy(instance->id, id, 1023);
 	instance->id[1023] = '\0';
 	instance->bpf_str = bpf_str;
-	instance->bpf = malloc(sizeof(struct bpf_program));
 
 	instance->packets_count = 0;
 	instance->bytes_count = 0;
 
-	if (pcap_compile(ctx->pcap_ctx, instance->bpf, bpf_str, 0, PCAP_NETMASK_UNKNOWN) == -1) {
-		fprintf(stderr, "Error at compiling bpf \"%s\": %s\n", bpf_str, pcap_geterr(ctx->pcap_ctx));
-		exit(1);
-	}
+	filters_prepare_pcap(instance, device, epoll_fd);
 
 	list_insert(ctx->filters, instance);
 }
 
-void filters_load(filters_ctx *ctx, const char *filterfile_path, const char *mac_addr) {
+void filters_load(filters_ctx *ctx, const char *filterfile_path, const char *mac_addr, const char* device, int epoll_fd) {
 	// TODO: test with /dev/random as input
 
 	FILE *fp = fopen(filterfile_path, "r");
 	char *line = NULL;
 	size_t read = 0;
 	int line_no = 0;
+
+	fprintf(stderr, "Device: %s\n", device);
 
 	if (fp == NULL) {
 		fprintf(stderr, "Error while opening the filterfile '%s': ", filterfile_path);
@@ -104,7 +173,7 @@ void filters_load(filters_ctx *ctx, const char *filterfile_path, const char *mac
 
 		fprintf(stderr, "id: %s; bpf: \"%s\";\n", id, bpf);
 		
-		filters_add(ctx, id, bpf);
+		filters_add(ctx, id, bpf, device, epoll_fd);
 	}
 
 	filters_bpfstr_unwind_finish(ctx);
@@ -112,13 +181,17 @@ void filters_load(filters_ctx *ctx, const char *filterfile_path, const char *mac
 	fclose(fp);
 }
 
-void filters_process(filters_ctx *ctx, const struct pcap_pkthdr *pkthdr, const u_char *packet) {
-	list_foreach(ctx->filters, f) {
-		struct filter *tmp = list_data(f, struct filter);
+void filters_process(u_char *ptr, const struct pcap_pkthdr *pkthdr, const u_char *packet) {
+	struct filter *filter = (struct filter *)ptr;
 		
-		if (pcap_offline_filter(tmp->bpf, pkthdr, packet)) {
-			tmp->packets_count += 1;
-			tmp->bytes_count += pkthdr->len;
-		}
+	filter->packets_count += 1;
+	filter->bytes_count += pkthdr->len;
+}
+
+void filters_break(filters_ctx *filters_ctx) {
+	list_foreach(filters_ctx->filters, f) {
+		struct filter *filter = list_data(f, struct filter);
+
+		pcap_breakloop(filter->pcap_ctx);
 	}
 }

--- a/filters.h
+++ b/filters.h
@@ -17,6 +17,7 @@ struct filter {
 typedef struct {
 	pcap_t *pcap_ctx;
 	struct list *filters;
+	int count;
 } filters_ctx;
 
 void filters_init(filters_ctx *ctx);

--- a/filters.h
+++ b/filters.h
@@ -7,6 +7,7 @@
 
 struct filter {
 	char id[1024];
+	char *bpf_str;
 	struct bpf_program *bpf;
 	unsigned long long packets_count;
 	unsigned long long bytes_count;
@@ -19,7 +20,7 @@ typedef struct {
 
 void filters_init(filters_ctx *ctx, pcap_t* pcap_ctx);
 void filters_finish(filters_ctx *ctx);
-void filters_add(filters_ctx *ctx, const char *id, const char* bpf_str);
+void filters_add(filters_ctx *ctx, const char *id, char *bpf_str);
 void filters_load(filters_ctx *ctx, const char *filterfile_path, const char* mac_addr);
 
 void filters_process(filters_ctx *ctx, const struct pcap_pkthdr *pkthdr, const u_char *packet);

--- a/filters.h
+++ b/filters.h
@@ -8,9 +8,10 @@
 struct filter {
 	char id[1024];
 	char *bpf_str;
-	struct bpf_program *bpf;
 	unsigned long long packets_count;
 	unsigned long long bytes_count;
+	pcap_t *pcap_ctx;
+	int fd;
 };
 
 typedef struct {
@@ -18,11 +19,12 @@ typedef struct {
 	struct list *filters;
 } filters_ctx;
 
-void filters_init(filters_ctx *ctx, pcap_t* pcap_ctx);
+void filters_init(filters_ctx *ctx);
 void filters_finish(filters_ctx *ctx);
-void filters_add(filters_ctx *ctx, const char *id, char *bpf_str);
-void filters_load(filters_ctx *ctx, const char *filterfile_path, const char* mac_addr);
+void filters_add(filters_ctx *ctx, const char *id, char *bpf_str, const char* device, int epoll_fd);
+void filters_load(filters_ctx *ctx, const char *filterfile_path, const char* mac_addr, const char* device, int epoll_fd);
 
-void filters_process(filters_ctx *ctx, const struct pcap_pkthdr *pkthdr, const u_char *packet);
+void filters_process(u_char *ptr, const struct pcap_pkthdr *pkthdr, const u_char *packet);
+void filters_break(filters_ctx *filters_ctx);
 
 #endif

--- a/usock.h
+++ b/usock.h
@@ -4,7 +4,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-int usock_prepare(const char* path);
+int usock_prepare(const char* path, const int epoll_fd);
 int usock_accept(int sock);
 void usock_finish(int sock);
 void usock_sendstr(int client_sock, const char* str);

--- a/util.c
+++ b/util.c
@@ -23,6 +23,7 @@ void get_mac(char *dest, const char *iface) {
 }
 
 void strnrepl(const char *token, const char *replace, char *str, size_t n) {
+	const size_t str_br_len = strlen("()");
 	char *ptr = str;
 	char *p_behind;
 	size_t length_new = strlen(str);
@@ -36,15 +37,24 @@ void strnrepl(const char *token, const char *replace, char *str, size_t n) {
 			return;
 
 		// calculate the new length and check for overflow
-		length_new += strlen(replace) - strlen(token);
+		length_new += strlen(replace) - strlen(token) + str_br_len;
 		if (length_new >= n)
 			return;
 
 		// this points to the position behind the token
 		p_behind = ptr + strlen(token);
 
-		memmove(ptr + strlen(replace), p_behind, strlen(p_behind));
+		// making room for replacement
+		memmove(ptr + strlen(replace) + str_br_len, p_behind,
+			strlen(p_behind));
+
+		// inserting replacement
+		*ptr = '(';
+		ptr += 1;
 		memcpy(ptr, replace, strlen(replace));
+		ptr += strlen(replace);
+		*ptr = ')';
+
 		str[length_new] = 0x00;
 	}
 }


### PR DESCRIPTION
Hi,

I did some tests with using kernelspace filtering (pcap_setfilter()) instead of the current userspace filtering within bpfcountd (pcap_offline_filter()).

I was hoping to reduce the impact of running bpfcountd on unrelated, unmatched traffic. So that maybe we could run bpfcountd on Freifunk gateways or Gluon mesh nodes to measure the broadcast and mesh routing protocol overhead without affecting the unicast performance / user experience.

However the results I'm getting on my laptop are quite mixed. There kernel space filtering has less impact on the unrelated, unmatched traffic compared to the current approach - but only until about 50 rules. After that the kernel space filtering is actually having a worse effect on the unicast traffic than the current userspace filtering approach (with a single core CPU probably the break-even point is probably at a few more rules).

The userspace filtering has roughly a constant 43% reduction in unicast performance. No matter how many rules I use. Only after about 500 arp rules bpfcountd uses one CPU core at about 100%. And then the unicast throughput actually gets a bit faster, probably because libpcap starts to drop packets.

Nevertheless, the kernelspace filtering is far from having no impact on the unicast traffic. Which I did not quite expect. I probably ask on the tcpdump mailing list for explanations.

-----

### Test protocol

Tests run on a laptop with a veth interface pair:

TX: iperf3 -t 15 -P 16 -c fe80::1%veth-tx (on veth-tx, fe80::2)
RX: iperf3 -s (on veth-rx, fe80::1)
LD_LIBRARY_PATH=/home/linus/dev-priv/libpcap/ ./bpfcountd -i veth-rx -f ./filter-test

Hardware:
* Thinkpad T480s
* Intel(R) Core(TM) i7-8550U CPU, 8 cores

Software:
* Linux 5.7.19
* Debian Sid
* libpcap master branch:
    5a89e579 Add support for B.A.T.M.A.N. Advanced
    bcd6c3fe Mention DLT_LINUX_SLL2 in INSTALL.md [skip ci]
          => CommitDate: Mon Nov 2 09:54:24 2020 +0000
    ...
* bpfcountd:
  A) userspace filtering / pcap_offline_filter()
     53faac0 Fix hangs on quiet interface with epoll for pcap handler + unix socket
     ...
     => https://github.com/T-X/bpfcountd/tree/test-userspace-filtering
  B) kernelspace filtering / pcap_setfilter()
     4776054 Speedup shutdown via pthreads
     80b455e WIP / DONT MERGE: Switch from userspace to kernelspace BPF filtering
     ...
     => https://github.com/T-X/bpfcountd/tree/test-kernelspace-filtering

Note 1: iperf3's -P 16 does not seem to work with a veth pair, still all threads of the
iperf3 client were running on the same CPU core.

Note 2: Small variations in throughput because it's a laptop and thermal CPU throttling
kicks in quickly. However short 15 seconds iperf runs seems to be fine, the hard impact
on throughput due to CPU throttling kicks in at about 30 seconds of iperf3 runtime.

Note 3: Number of pcap handles seems to be limited to 510 on a Linux 5.7.19 kernel.
Therefore test B / kernelspace results are not available for more than 500 rules.

0x arp / no bpfcountd:

73.8 Gbits/sec (-0.0%),     CPU: 100% iperf3 server, 100% iperf3 client, no bpfcountd

1x arp:

A) 43.4 Gbits/sec (-41.2%), CPU: 100% iperf3 server, 100% iperf3 client, 8% bpfcountd
B) 71.7 Gbits/sec (-2.8%),  CPU: 100% iperf3 server, 100% iperf3 client, 0% bpfcountd

5x arp:

A) 43.3 Gbits/sec (-41.3%), CPU: 100% iperf3 server, 100% iperf3 client, 8.5% bpfcountd
B) 70.3 Gbits/sec (-4.7%),  CPU: 100% iperf3 server, 100% iperf3 client, 0% bpfcountd

10x arp:

A) 42.6 Gbits/sec (-42.3%), CPU: 100% iperf3 server, 100% iperf3 client, 9.5% bpfcountd
B) 65.7 Gbits/sec (-11.0%), CPU: 100% iperf3 server, 100% iperf3 client, 0% bpfcountd

50x arp:

A) 42.0 Gbits/sec (-43.1%), CPU: 100% iperf3 server, 100% iperf3 client, 20% bpfcountd
B) 45.8 Gbits/sec (-37.9%), CPU: 100% iperf3 server, 100% iperf3 client, 0% bpfcountd

100x arp:

A) 42.6 Gbits/sec (-42.3%), CPU: 100% iperf3 server, 100% iperf3 client, 30% bpfcountd
B) 31.0 Gbits/sec (-58.0%), CPU: 100% iperf3 server, 38% iperf3 client, 0% bpfcountd

250x arp:

A) 41.8 Gbits/sec (-43.4%), CPU: 100% iperf3 server, 100% iperf3 client, 70% bpfcountd
B) 11.1 Gbits/sec (-85.0%), CPU: 100% iperf3 server, 18.5% iperf3 client, 0% bpfcountd

500x arp:

A) 45.7 Gbits/sec (-38.1%), CPU: 100% iperf3 server, 100% iperf3 client, 100% bpfcountd
B) 5.39 Gbits/sec (-92.7%), CPU: 100% iperf3 server, 10% iperf3 client, 0% bpfcountd

750x arp:

A) 51.1 Gbits/sec (-30.8%), CPU: 100% iperf3 server, 100% iperf3 client, 100% bpfcountd
B) -

1000x arp:

A) 56.0 Gbits/sec (-24.1%), CPU: 100% iperf3 server, 100% iperf3 client, 100% bpfcountd
B) -

1500x arp:

A) 55.3 Gbits/sec (-25.1%), CPU: 100% iperf3 server, 100% iperf3 client, 100% bpfcountd
B) -

3000x arp:

A) 59.2 Gbits/sec (-19.8%), CPU: 100% iperf3 server, 100% iperf3 client, 100% bpfcountd
B) -

