### PR TITLE
Introduce kernel prefilter to reduce overhead on other traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ icmp6:100:4
 arp-reply-gratious:120:30
 ```
 
+**Kernel Prefilter**
+
+To reduce the impact on unrelated traffic, a prefilter should be configured.
+If set only packets matching the prefilter will be copied to userspace for
+further examination by bpfcountd.
+
 **Use with prometheus node_exporter:**
 
 Add a crontab:
@@ -78,8 +84,9 @@ $> cp dist/systemd@.service /lib/systemd/system/bpfcountd@.service
 
 ``` shell
 $> bpfcountd -h
-bpfcountd -i <interface> -f <filterfile> [-u <unixpath>] [-h]
+bpfcountd -i <interface> [-F <prefilter-expr>] -f <filterfile> [-u <unixpath>] [-h]
 
+-F <prefilter-expr>   an optional prefilter BPF expression, installed in the kernel
 -f <filterfile>       a the main file where each line contains an id and a bpf
                       filter, seperated by a semicolon
 -u <unixpath>         path to the unix info socket (default is ./test.sock)

--- a/filters.c
+++ b/filters.c
@@ -43,7 +43,7 @@ static void filters_bpfstr_unwind_finish(filters_ctx *ctx)
 		free(list_data(f, struct filter)->bpf_str);
 }
 
-void filters_add(filters_ctx *ctx, const char *id, char *bpf_str) {
+static void filters_add(filters_ctx *ctx, const char *id, char *bpf_str) {
 	struct filter *instance = malloc(sizeof(*instance));
 
 	// TODO: document maximum len of id

--- a/filters.h
+++ b/filters.h
@@ -20,7 +20,6 @@ typedef struct {
 
 void filters_init(filters_ctx *ctx, pcap_t* pcap_ctx);
 void filters_finish(filters_ctx *ctx);
-void filters_add(filters_ctx *ctx, const char *id, char *bpf_str);
 void filters_load(filters_ctx *ctx, const char *filterfile_path, const char* mac_addr);
 
 void filters_process(filters_ctx *ctx, const struct pcap_pkthdr *pkthdr, const u_char *packet);

--- a/main.c
+++ b/main.c
@@ -12,7 +12,7 @@
 
 #define MAX_EVENTS 32
 
-struct epoll_event events[MAX_EVENTS];
+static struct epoll_event events[MAX_EVENTS];
 
 struct config {
 	const char *device;       // TODO: rename
@@ -30,7 +30,7 @@ typedef struct {
 } bpfcountd_ctx;
 
 
-void prepare_pcap(bpfcountd_ctx *ctx, const char* device, int epoll_fd) {
+static void prepare_pcap(bpfcountd_ctx *ctx, const char* device, int epoll_fd) {
 	struct epoll_event event;
 	char errbuf[PCAP_ERRBUF_SIZE];
 
@@ -66,7 +66,7 @@ void prepare_pcap(bpfcountd_ctx *ctx, const char* device, int epoll_fd) {
 	fprintf(stderr, "Device: %s\n", device);
 }
 
-void help(const char* path) {
+static void help(const char* path) {
 	fprintf(stderr, "%s -i <interface> -f <filterfile> [-u <unixpath>] [-h]\n\n", path);
 
 	fprintf(stderr, "-f <filterfile>       a the main file where each line contains an id and a bpf\n");
@@ -74,7 +74,7 @@ void help(const char* path) {
 	fprintf(stderr, "-u <unixpath>         path to the unix info socket (default is ./test.sock)\n");
 }
 
-void prepare_config(struct config *cfg, int argc, char *argv[]){
+static void prepare_config(struct config *cfg, int argc, char *argv[]) {
 	int c;
 
 	// default settings
@@ -126,19 +126,20 @@ void prepare_config(struct config *cfg, int argc, char *argv[]){
 }
 
 
-void callback(u_char *ptr, const struct pcap_pkthdr *pkthdr, const u_char *packet)
+static void callback(u_char *ptr, const struct pcap_pkthdr *pkthdr, const u_char *packet)
 {
 	bpfcountd_ctx *ctx = (bpfcountd_ctx *) ptr;
 	filters_process(&ctx->filters_ctx, pkthdr, packet);
 }
 
-int term = 0;
+static int term = 0;
 
-void sigint_handler(int signo) {
+static void sigint_handler(int signo) {
 	term = 1;
 }
 
-void bpfcountd_init(bpfcountd_ctx *ctx, int argc, char *argv[], int epoll_fd) {
+static void
+bpfcountd_init(bpfcountd_ctx *ctx, int argc, char *argv[], int epoll_fd) {
 	prepare_config(&ctx->config, argc, argv);
 
 	// get a pcap handle
@@ -153,7 +154,7 @@ void bpfcountd_init(bpfcountd_ctx *ctx, int argc, char *argv[], int epoll_fd) {
 	);
 }
 
-void bpfcountd_finish(bpfcountd_ctx *ctx) {
+static void bpfcountd_finish(bpfcountd_ctx *ctx) {
 	close(ctx->fd);
 	pcap_close(ctx->pcap_ctx);
 	filters_finish(&ctx->filters_ctx);


### PR DESCRIPTION
So far all packets are copied to userspace before any filters are
applied and before counting is performed. This can have a significant
impact on performance for unrelated traffic.
    
This introduces a new command line option "-F <prefilter-expr>" which
allows specifying a BPF filter expression which prefilters any packets
before being copied to userspace for further examination in bpfcountd.
    
Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>