### PR TITLE
Add missing include for strncpy + memset in usock.c

### DIFF
--- a/usock.c
+++ b/usock.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/epoll.h> // for epoll_ctl(), struct epoll_event


### PR DESCRIPTION
Building bpfcountd on OpenWrt 19.07 (GCC 7.5.0, musl 1.1.24) fails with
the following build error:

  usock.c: In function 'usock_prepare':
  usock.c:22:2: error: implicit declaration of function 'strncpy' [-Werror=implicit-function-declaration]
    strncpy(local.sun_path, path, sizeof(local.sun_path) -1);
    ^~~~~~~
  usock.c:22:2: error: incompatible implicit declaration of built-in function 'strncpy' [-Werror]
  usock.c:22:2: note: include '<string.h>' or provide a declaration of 'strncpy'
  usock.c:40:2: error: implicit declaration of function 'memset' [-Werror=implicit-function-declaration]
    memset(&event, 0, sizeof(event));
    ^~~~~~
  usock.c:40:2: error: incompatible implicit declaration of built-in function 'memset' [-Werror]
  usock.c:40:2: note: include '<string.h>' or provide a declaration of 'memset'

Fix this by adding the missing include to string.h to usock.c.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>