### PR TITLE
Makefile: always append -lpcap to LDFLAGS to ease cross-compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC?=gcc
 
 CFLAGS+=-Wall -Werror -ggdb
-LDFLAGS?=-lpcap
+LDFLAGS+=-lpcap
 NAME=bpfcountd
 PREFIX?=/usr/local
 


### PR DESCRIPTION
When cross-compiling bpfcountd OpenWrt for example sets LDFLAGS. However
even when specifying "DEPENDS:= +libpcap" in the OpenWrt Makefile it
will not add "-lpcap", leading errors like the following when linking:

...filters.c:119: undefined reference to `pcap_offline_filter'
collect2: error: ld returned 1 exit status

One workaround for this is to set "TARGET_LDFLAGS += -lpcap" in the
OpenWrt Makefile for bpfcountd. However the nicer way is to just always
append "-lpcap", even if the caller has set LDFLAGS. This works without
the TARGET_LDFLAGS workaround.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>