### PR TITLE
Add option to configure libpcap capture buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ $> cp dist/systemd@.service /lib/systemd/system/bpfcountd@.service
 
 ``` shell
 $> bpfcountd -h
-bpfcountd -i <interface> [-F <prefilter-expr>] -f <filterfile> [-u <unixpath>] [-h]
+bpfcountd -i <interface> [-F <prefilter-expr>] -f <filterfile>
+          [-b <buffer-size>] [-u <unixpath>] [-h]
 
 -F <prefilter-expr>   an optional prefilter BPF expression, installed in the kernel
 -f <filterfile>       a the main file where each line contains an id and a bpf
                       filter, seperated by a semicolon
+-b <buffer-size>      size of the capture buffer in bytes (default: 2*1024*1024)
 -u <unixpath>         path to the unix info socket (default is ./test.sock)
 ```
 


### PR DESCRIPTION
The default libpcap buffer size is 2MB. This might be quite large when running bpfcountd on an embedded system. Or too small when capturing traffic at a high bitrate. Therefore making it configurable.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>